### PR TITLE
Alteração no método de extração do PlayFabId

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,7 @@ conn.on('auth', () => {
     }
 }).on('server', str => {
     if (str.startsWith('Killfeed')) {
-        kill = str.replace(/^(?:[^\:]+\:){2}\s*/, '')
-        kill = kill.replace(/\([^()]*\)/g, '')
-        arr = kill.replace(/ /g, '').split('killed')
+        arr = str.match(/([0-9A-F]{16})/gm)
         console.log(arr)
         database.addKill(arr[0], arr[1])
     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ conn.on('auth', () => {
     }
 }).on('server', str => {
     if (str.startsWith('Killfeed')) {
-        arr = str.match(/([0-9A-F]{16})/gm)
+        arr = str.match(/([0-9A-F]{14,16})/gm)
         console.log(arr)
         database.addKill(arr[0], arr[1])
     }


### PR DESCRIPTION
Alterado método de extração no PlayFabId, no método anterior um nome que contenha Parênteses iria causar  a inserção de  parte do nome no banco como parte do PlayFabId.
Com esse Regex ele vai estrair strings de 16 carecteres em Hexa, o que  imagino que tenha bem menos chance de acontecer do que um nome que contenha () nele